### PR TITLE
[BUG] Fix iOS addObserver

### DIFF
--- a/src/iosMain/kotlin/com/github/florent37/livedata/KLiveData.kt
+++ b/src/iosMain/kotlin/com/github/florent37/livedata/KLiveData.kt
@@ -74,13 +74,14 @@ actual open class KLiveData<T> {
     }
 
     internal fun addObserver(lifecycle: KLifecycle, block: (T) -> Unit){
-        var lifecycleAndObserver = this.lifecycleObservers.get(lifecycle)
+        var lifecycleAndObserver = this.lifecycleObservers[lifecycle]
         if(lifecycleAndObserver == null){
             lifecycleAndObserver = KLifecycleAndObserver(lifecycle)
 
             lifecycle.addStopObserver {
                 lifecycleObservers.remove(lifecycle)
             }
+            this.lifecycleObservers[lifecycle] = lifecycleAndObserver
         }
         lifecycleAndObserver.observers.add(block)
 


### PR DESCRIPTION
Bug Description:
When the `KLiveData.observe(lifecycle,block)`  was called from iOS the observer was never notified with the updated values.

Root cause: 
When calling the `addObserver` on the iOS actual implementation the `KLifecycleAndObserver` object was never added to the `lifecycleObservers` map so when the livedata emits an item the observer list is empty.